### PR TITLE
fix: change GetIPByCaseID to return multiple records

### DIFF
--- a/internal/repository/intellectual_property_repo.go
+++ b/internal/repository/intellectual_property_repo.go
@@ -38,12 +38,12 @@ func (r *IntellectualPropertyRepo) GetIPByID(ipID string) (*models.IntellectualP
 // 🟢 GetIPByCaseID
 func (r *IntellectualPropertyRepo) GetIPByCaseID(caseID string) ([]models.IntellectualProperties, error) {
 	var ip []models.IntellectualProperties
-	err := r.DB.Where("case_id = ?", caseID).Find(&ip).Error
-	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("intellectual property with case_id %s not found", caseID)
-		}
-		return nil, err
+	err := r.DB.Where("case_id = ?", caseID).Find(&ip)
+	if err.Error != nil {
+		return nil, err.Error
+	}
+	if err.RowsAffected == 0 {
+		return nil, fmt.Errorf("intellectual property with case_id %s not found", caseID)
 	}
 	return ip, nil
 }

--- a/internal/repository/intellectual_property_repo.go
+++ b/internal/repository/intellectual_property_repo.go
@@ -36,16 +36,16 @@ func (r *IntellectualPropertyRepo) GetIPByID(ipID string) (*models.IntellectualP
 }
 
 // 🟢 GetIPByCaseID
-func (r *IntellectualPropertyRepo) GetIPByCaseID(caseID string) (*models.IntellectualProperties, error) {
-	var ip models.IntellectualProperties
-	err := r.DB.Where("case_id = ?", caseID).First(&ip).Error
+func (r *IntellectualPropertyRepo) GetIPByCaseID(caseID string) ([]models.IntellectualProperties, error) {
+	var ip []models.IntellectualProperties
+	err := r.DB.Where("case_id = ?", caseID).Find(&ip).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, fmt.Errorf("intellectual property with case_id %s not found", caseID)
 		}
 		return nil, err
 	}
-	return &ip, nil
+	return ip, nil
 }
 
 // 🟢 CreateIP - auto generate ID IP-00001

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -70,7 +70,7 @@ type AssessmentRepository interface {
 type IntellectualPropertyRepository interface {
 	GetIPAll() ([]models.IntellectualProperties, error)
 	GetIPByID(ipID string) (*models.IntellectualProperties, error)
-	GetIPByCaseID(caseID string) (*models.IntellectualProperties, error)
+	GetIPByCaseID(caseID string) ([]models.IntellectualProperties, error)
 	CreateIP(ip *models.IntellectualProperties) error
 	UpdateIPByID(ipID string, data map[string]interface{}) error
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed case lookup to retrieve and display all intellectual property records tied to a case (previously limited to a single record). Improved handling when no records are found so the UI reflects absence of results consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->