### PR TITLE
fix: remove anti-spam cooldown for appointment update notifications

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,15 +13,14 @@ import (
 )
 
 type Config struct {
-	DBUrl            string
-	Port             string
-	EmailHost        string
-	EmailPort        string
-	EmailSender      string
-	EmailPassword    string
-	AntiSpamCooldown string
-	JWTExpiry        string
-	JWTExpiryTemp    string
+	DBUrl         string
+	Port          string
+	EmailHost     string
+	EmailPort     string
+	EmailSender   string
+	EmailPassword string
+	JWTExpiry     string
+	JWTExpiryTemp string
 }
 
 func (c Config) GetSMTPConfig() send_email.SMTPConfig {
@@ -32,14 +31,6 @@ func (c Config) GetSMTPConfig() send_email.SMTPConfig {
 		Password: c.EmailPassword,
 		From:     c.EmailSender,
 	}
-}
-
-func (c Config) GetAntiSpamCooldown() time.Duration {
-	d, err := time.ParseDuration(c.AntiSpamCooldown)
-	if err != nil {
-		return 15 * time.Minute // Default fall back
-	}
-	return d
 }
 
 func (c Config) GetJWTExpiry() time.Duration {
@@ -89,15 +80,14 @@ func LoadConfig() Config {
 	}
 
 	return Config{
-		DBUrl:            dbURL,
-		Port:             os.Getenv("PORT"),
-		EmailHost:        os.Getenv("EMAIL_HOST"),
-		EmailPort:        os.Getenv("EMAIL_PORT"),
-		EmailSender:      os.Getenv("EMAIL_USER"),
-		EmailPassword:    os.Getenv("EMAIL_PASS"),
-		AntiSpamCooldown: getEnv("ANTISPAM_COOLDOWN", "15m"),
-		JWTExpiry:        getEnv("JWT_EXPIRY", "480"),
-		JWTExpiryTemp:    getEnv("JWT_EXPIRY_TEMP", "10"),
+		DBUrl:         dbURL,
+		Port:          os.Getenv("PORT"),
+		EmailHost:     os.Getenv("EMAIL_HOST"),
+		EmailPort:     os.Getenv("EMAIL_PORT"),
+		EmailSender:   os.Getenv("EMAIL_USER"),
+		EmailPassword: os.Getenv("EMAIL_PASS"),
+		JWTExpiry:     getEnv("JWT_EXPIRY", "480"),
+		JWTExpiryTemp: getEnv("JWT_EXPIRY_TEMP", "10"),
 	}
 }
 

--- a/internal/handlers/appointment_handler.go
+++ b/internal/handlers/appointment_handler.go
@@ -177,7 +177,7 @@ func (h *AppointmentHandler) UpdateAppointmentByID(c *gin.Context) {
 	c.JSON(http.StatusOK, newAp)
 }
 
-// ProcessUpdateNotification handles meaningful change detection, anti-spam, and email sending
+// ProcessUpdateNotification handles meaningful change detection and update email sending
 func (h *AppointmentHandler) ProcessUpdateNotification(oldAp *models.Appointments, newAp *models.Appointments) {
 	// A. Detect meaningful changes
 	changedFields := make(map[string]bool)

--- a/internal/handlers/appointment_handler.go
+++ b/internal/handlers/appointment_handler.go
@@ -207,17 +207,9 @@ func (h *AppointmentHandler) ProcessUpdateNotification(oldAp *models.Appointment
 
 	log.Printf("[Notification] Meaningful changes detected for %s: %+v", newAp.ID, changedFields)
 
-	// B. Anti-spam Protection
 	now := time.Now()
-	diff := now.Sub(oldAp.UpdatedAt)
-	cooldown := h.Cfg.GetAntiSpamCooldown()
-	if diff < cooldown {
-		log.Printf("[Notification] Anti-spam: Skipping email for %s. Last meaningful update was only %v ago (limit: %v)", newAp.ID, diff.Round(time.Second), cooldown)
-		return
-	}
-	log.Printf("[Notification] Anti-spam cleared for %s. Last update: %v (diff: %v, limit: %v)", newAp.ID, oldAp.UpdatedAt.Format("15:04:05"), diff.Round(time.Minute), cooldown)
 
-	// C. Prepare Email Data
+	// B. Prepare Email Data
 	details, _ := send_email.GatherAppointmentEmailData(newAp)
 	emailService := send_email.CreateSMTPEmailService(h.Cfg.GetSMTPConfig())
 
@@ -243,7 +235,7 @@ func (h *AppointmentHandler) ProcessUpdateNotification(oldAp *models.Appointment
 	subject := "[URGENT] Appointment Details Updated"
 	updatedAtStr := now.Format("02 Jan 2006 15:04:05")
 
-	// D. Send Emails
+	// C. Send Emails
 	anySuccess := false
 	for email, name := range recipients {
 		recipient := send_email.Recipient{Name: name, Email: email}
@@ -258,7 +250,7 @@ func (h *AppointmentHandler) ProcessUpdateNotification(oldAp *models.Appointment
 		}
 	}
 
-	// E. Log results
+	// D. Log results
 	if anySuccess {
 		log.Printf("[Notification] Successfully sent update emails for %s", newAp.ID)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed rate-limiting on appointment update emails—recipients will now receive update notifications more frequently (still only for meaningful changes and when recipients exist).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->