### PR TITLE
feat: add duplicate email validation on user creation

### DIFF
--- a/internal/handlers/admin_handler.go
+++ b/internal/handlers/admin_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 type AdminHandler struct {
@@ -82,7 +83,13 @@ func (h *AdminHandler) CreateAdmin(c *gin.Context) {
 	}
 
 	// Check if email already exists
-	if existingAdmin, _ := h.Repo.GetAdminByEmail(req.Email); existingAdmin != nil {
+	existingAdmin, err := h.Repo.GetAdminByEmail(req.Email)
+	if err != nil && err != gorm.ErrRecordNotFound {
+		log.Printf("CreateAdmin: failed to check email uniqueness: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to validate email uniqueness"})
+		return
+	}
+	if existingAdmin != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "email already exists"})
 		return
 	}

--- a/internal/handlers/admin_handler.go
+++ b/internal/handlers/admin_handler.go
@@ -81,6 +81,12 @@ func (h *AdminHandler) CreateAdmin(c *gin.Context) {
 		return
 	}
 
+	// Check if email already exists
+	if existingAdmin, _ := h.Repo.GetAdminByEmail(req.Email); existingAdmin != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "email already exists"})
+		return
+	}
+
 	// Hash password
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {

--- a/internal/handlers/researcher_handler.go
+++ b/internal/handlers/researcher_handler.go
@@ -90,6 +90,12 @@ func (h *ResearcherHandler) CreateResearcher(c *gin.Context) {
 		return
 	}
 
+	// Check if email already exists
+	if existingResearcher, _ := h.Repo.GetResearcherByEmail(req.Email); existingResearcher != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "email already exists"})
+		return
+	}
+
 	// Hash password
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {

--- a/internal/handlers/researcher_handler.go
+++ b/internal/handlers/researcher_handler.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	"gorm.io/gorm"
+
 	"golang.org/x/crypto/bcrypt"
 
 	"trl-research-backend/internal/entity"
@@ -91,7 +93,13 @@ func (h *ResearcherHandler) CreateResearcher(c *gin.Context) {
 	}
 
 	// Check if email already exists
-	if existingResearcher, _ := h.Repo.GetResearcherByEmail(req.Email); existingResearcher != nil {
+	existingResearcher, err := h.Repo.GetResearcherByEmail(req.Email)
+	if err != nil && err != gorm.ErrRecordNotFound {
+		log.Printf("CreateResearcher: failed to check email uniqueness: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to validate email uniqueness"})
+		return
+	}
+	if existingResearcher != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "email already exists"})
 		return
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added email uniqueness validation during admin and researcher account creation. Attempting to register with an existing email now returns a 409 Conflict error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->